### PR TITLE
Improve random number generation

### DIFF
--- a/diffusion/mcrw/transit.py
+++ b/diffusion/mcrw/transit.py
@@ -5,17 +5,14 @@ import numpy as np
 
 class TransitABC(ABC):
 
-    @classmethod
     @abstractmethod
-    def probability(cls, dx_i, dx_j, D_i, D_j, P):
+    def probability(self, dx_i, dx_j, D_i, D_j, P):
         pass
 
-    @classmethod
-    def _crossing(cls, decision, dx_i, dx_j, D_i, D_j):
+    def _crossing(self, decision, dx_i, dx_j, D_i, D_j):
         dx_j[decision] *= np.sqrt(D_j/D_i)[decision]  # modify in-place
 
-    @classmethod
-    def crosses(cls, dx_i, dx_j, D_i, D_j, P):
+    def crosses(self, dx_i, dx_j, D_i, D_j, P):
         p_t = cls.probability(dx_i, dx_j, D_i, D_j, P)
         uval = np.random.uniform(0, 1, dx_j.size)
         decision = uval <= p_t
@@ -30,6 +27,7 @@ class Constant(TransitABC):
     """
 
     def __init__(self, p_t=0.5):
+        super().__init__()  # call superclass constructor
         self.p_t = p_t
 
     def probability(self, *args):
@@ -41,8 +39,7 @@ class Parrot(TransitABC):
     Clips the value of permeability to [0, 1]
     """
 
-    @classmethod
-    def probability(cls, dx_i, dx_j, D_i, D_j, P):
+    def probability(self, dx_i, dx_j, D_i, D_j, P):
         p_t = np.clip(P, 0, 1)
         return p_t
 
@@ -52,8 +49,7 @@ class Maruyama2017(TransitABC):
     Based on (Maruyama, 2017, DOI:10.1103/PhysRevE.96.032135)
     """
 
-    @classmethod
-    def probability(cls, dx_i, dx_j, D_i, D_j, P):
+    def probability(self, dx_i, dx_j, D_i, D_j, P):
         p_t = np.minimum(np.sqrt(D_j/D_i), 1.0)
         return p_t
 
@@ -63,8 +59,7 @@ class Fieremans2010(TransitABC):
     Based on (Fieremans et al, 2010, DOI:10.1002/nbm.1577)
     """
 
-    @classmethod
-    def probability(cls, dx_i, dx_j, D_i, D_j, P):
+    def probability(self, dx_i, dx_j, D_i, D_j, P):
         term = 2*dx_i*P/D_i
         p_t = np.where(np.isinf(P), 1, term/(1+term))
         return p_t
@@ -75,8 +70,7 @@ class Szafer1995(TransitABC):
     Based on (Szafer et al, 1995, DOI:10.1002/mrm.1910330516)
     """
 
-    @classmethod
-    def probability(cls, dx_i, dx_j, D_i, D_j, P):
+    def probability(self, dx_i, dx_j, D_i, D_j, P):
         dx = dx_i + dx_j
         v_i = 2*D_i/dx
         p_t = 4*P/v_i

--- a/diffusion/mcrw/transit.py
+++ b/diffusion/mcrw/transit.py
@@ -5,6 +5,9 @@ import numpy as np
 
 class TransitABC(ABC):
 
+    def __init__(self):
+        self._rng = np.random.default_rng()
+
     @abstractmethod
     def probability(self, dx_i, dx_j, D_i, D_j, P):
         pass
@@ -12,11 +15,12 @@ class TransitABC(ABC):
     def _crossing(self, decision, dx_i, dx_j, D_i, D_j):
         dx_j[decision] *= np.sqrt(D_j/D_i)[decision]  # modify in-place
 
-    def crosses(self, dx_i, dx_j, D_i, D_j, P):
-        p_t = cls.probability(dx_i, dx_j, D_i, D_j, P)
-        uval = np.random.uniform(0, 1, dx_j.size)
-        decision = uval <= p_t
-        cls._crossing(decision, dx_i, dx_j, D_i, D_j)
+    def crosses(self, dx_i, dx_j, D_i, D_j, P, *, rng=None, exclude=None):
+        p_t = self.probability(dx_i, dx_j, D_i, D_j, P)
+        rng = self._rng if rng is None else rng
+        uval = rng.uniform(0, 1, dx_j.size)
+        decision = np.logical_and(uval <= p_t, np.logical_not(exclude))
+        self._crossing(decision, dx_i, dx_j, D_i, D_j)
         return decision
 
 


### PR DESCRIPTION
Use of `numpy.random.*` methods (e.g. `numpy.random.uniform`) for random number generation is discouraged. This PR changes the interface of `MonteCarlo` to support use of a random generator.

The `TransitABC` class is updated to allow an optional generator to be passed to the `.crosses` method.
